### PR TITLE
Add fice to tile states 

### DIFF
--- a/vector2tile_restart_mod.f90
+++ b/vector2tile_restart_mod.f90
@@ -34,6 +34,7 @@ module vector2tile_restart_mod
     double precision, allocatable :: snow_liq_layer     (:,:,:,:)
     double precision, allocatable :: temperature_soil   (:,:,:,:)
     real,             allocatable :: land_frac          (:,:,:)
+    double precision, allocatable :: ice_frac           (:,:,:)
     double precision, allocatable :: soil_moisture_total(:,:,:,:)
     double precision, allocatable :: vegetation_type(:,:,:)
 ! needed by add increments
@@ -82,6 +83,7 @@ contains
   allocate(tile%temperature_soil   (namelist%tile_size,namelist%tile_size,4,6))
   allocate(tile%soil_moisture_total  (namelist%tile_size,namelist%tile_size,4,6)) 
   allocate(tile%land_frac          (namelist%tile_size,namelist%tile_size,6))
+  allocate(tile%ice_frac           (namelist%tile_size,namelist%tile_size,6))
   allocate(tile%slmsk              (namelist%tile_size,namelist%tile_size,6))
   allocate(tile%vegetation_type    (namelist%tile_size,namelist%tile_size,6))
   allocate(tile%soil_moisture_liquid (namelist%tile_size,namelist%tile_size,4,6))
@@ -172,6 +174,7 @@ contains
         tile%temperature_soil(ix,iy,:,itile)    = vector%temperature_soil(iloc,:)
         tile%soil_moisture_total(ix,iy,:,itile) = vector%soil_moisture_total(iloc,:) 
         tile%slmsk(ix,iy,itile)                 = 1.
+        tile%ice_frac(ix,iy,itile)              = 0.                                   !10.20.25 added 0 fice at land locations for gfsv17
         tile%soil_moisture_liquid(ix,iy,:,itile)= vector%soil_moisture_liquid(iloc,:)
         tile%temperature_ground(ix,iy,itile)    = vector%temperature_ground(iloc)
       end if
@@ -561,6 +564,14 @@ contains
     status = nf90_get_var(ncid, varid , tile%temperature_ground(:,:,itile)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
 
+    status = nf90_inq_varid(ncid, "fice", varid)
+    if (status /= nf90_noerr) then
+        print *, 'fice variable missing from tile file'
+        call handle_err(status)
+    endif
+    status = nf90_get_var(ncid, varid , tile%ice_frac(:,:,itile)   , &
+      start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
+
     status = nf90_close(ncid)
 
   end do
@@ -680,9 +691,6 @@ contains
   integer             :: itile
   integer             :: ncid, varid, status, i
   integer             :: dim_id_xdim, dim_id_ydim, dim_id_soil, dim_id_snow, dim_id_snso, dim_id_time
-  
-  ! fraction of ice --all zero- but intended to enable GFSv17/fractional grids runs
-  real                :: frac_ice(namelist%tile_size, namelist%tile_size) = 0.
   
   do itile = 1, 6
 
@@ -896,9 +904,9 @@ contains
     status = nf90_put_var(ncid, varid , tile%vegetation_type(:,:,itile)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
 
-    ! fraction of ice --all zero
+    ! fraction of ice --all zero over land
     status = nf90_inq_varid(ncid, "fice", varid)
-    status = nf90_put_var(ncid, varid , frac_ice(:,:)   , &
+    status = nf90_put_var(ncid, varid , tile%ice_frac(:,:,itile)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
 
 ! include for JEDI QC of SMAP obs

--- a/vector2tile_restart_mod.f90
+++ b/vector2tile_restart_mod.f90
@@ -799,7 +799,7 @@ contains
       (/dim_id_xdim,dim_id_ydim,dim_id_time/), varid)
       if (status /= nf90_noerr) call handle_err(status)
       
-    status = nf90_def_var(ncid, "vtype", NF90_DOUBLE,   &
+   status = nf90_def_var(ncid, "vtype", NF90_DOUBLE,   &
       (/dim_id_xdim,dim_id_ydim,dim_id_time/), varid)
       if (status /= nf90_noerr) call handle_err(status)
 

--- a/vector2tile_restart_mod.f90
+++ b/vector2tile_restart_mod.f90
@@ -681,6 +681,9 @@ contains
   integer             :: ncid, varid, status, i
   integer             :: dim_id_xdim, dim_id_ydim, dim_id_soil, dim_id_snow, dim_id_snso, dim_id_time
   
+  ! fraction of ice --all zero- but intended to enable GFSv17/fractional grids runs
+  real                :: frac_ice(namelist%tile_size, namelist%tile_size) = 0.
+  
   do itile = 1, 6
 
     !write(tile_filename,'(a17,a19,a5,i1,a3)') "ufs_land_restart.", date, ".tile", itile, ".nc"
@@ -788,7 +791,7 @@ contains
       (/dim_id_xdim,dim_id_ydim,dim_id_time/), varid)
       if (status /= nf90_noerr) call handle_err(status)
       
-  status = nf90_def_var(ncid, "vtype", NF90_DOUBLE,   &
+    status = nf90_def_var(ncid, "vtype", NF90_DOUBLE,   &
       (/dim_id_xdim,dim_id_ydim,dim_id_time/), varid)
       if (status /= nf90_noerr) call handle_err(status)
 
@@ -797,6 +800,11 @@ contains
       if (status /= nf90_noerr) call handle_err(status)
 
     status = nf90_def_var(ncid, "tgxy", NF90_DOUBLE,   &
+      (/dim_id_xdim,dim_id_ydim,dim_id_time/), varid)
+      if (status /= nf90_noerr) call handle_err(status)
+
+    ! fraction of ice
+    status = nf90_def_var(ncid, "fice", NF90_DOUBLE,   &
       (/dim_id_xdim,dim_id_ydim,dim_id_time/), varid)
       if (status /= nf90_noerr) call handle_err(status)
 
@@ -886,6 +894,11 @@ contains
 
     status = nf90_inq_varid(ncid, "vtype", varid)
     status = nf90_put_var(ncid, varid , tile%vegetation_type(:,:,itile)   , &
+      start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
+
+    ! fraction of ice --all zero
+    status = nf90_inq_varid(ncid, "fice", varid)
+    status = nf90_put_var(ncid, varid , frac_ice(:,:)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
 
 ! include for JEDI QC of SMAP obs


### PR DESCRIPTION
## Describe your changes  
Summarise all code changes included in PR: 

Added fraction of ice (fice) to states saved in tile restarts--all zero over land. The read tile function also will look for fice variables to ensure consistency.


## Issue ticket number and link
https://github.com/NOAA-PSL/land-vector2tile/issues/15


## Test output 
Is this PR expected to pass the DA_IMS_test (ie., does it change the output)? 
Does it pass the DA_IMS_test? 

The DA with IMS and GHCN on C96 runs successfully.  Need to update the baseline for nccmp as there is now a new var.

If changes to the test results are expected, what are these changes? Provide a link to the output directory when running the test: 

## Checklist before requesting a review
- [x] My branch being merged is up to date with the latest develop. 
- [x] I have performed a self-review of my code by examining the differences that will be merged.
- [x] I have not made any unnecessary code changes / changed any default behavior.
- [x] My code passes the DA_IMS_test, or differences can be explained. 

