### PR TITLE
Bugfix for snodl issues

### DIFF
--- a/vector2tile_restart_mod.f90
+++ b/vector2tile_restart_mod.f90
@@ -429,9 +429,12 @@ contains
   integer             :: itile
   logical             :: file_exists
 
-  ! Oct 2025: GFSv17 vars used exclusively
-  snd_name = "snodl"
-  swe_name = "weasdl"
+  ! Oct 2025: GFSv17 vars used snodl and weasdl exclusively
+  ! But during vector2tile conversion, we calculate snodl=snwdph/land_frac
+  ! So should still read in the variable of snwdph and sheleg here
+  ! The conversion to snodl and weasdl always happen in the vector2tile at later time
+  snd_name = "snwdph"
+  swe_name = "sheleg"
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Create tile file name
@@ -859,8 +862,8 @@ contains
     status = nf90_put_var(ncid, varid , tile%swe(:,:,itile)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
     
-    swe_snd_land = 0.   !tile%swe(:,:,itile)
-    where(tile%land_frac(:,:,itile) > 0.) swe_snd_land = tile%swe(:,:,itile)/tile%land_frac(:,:,itile)
+    swe_snd_land = -1e20   !tile%swe(:,:,itile)
+    where(tile%land_frac(:,:,itile) > 0.5) swe_snd_land = tile%swe(:,:,itile)/tile%land_frac(:,:,itile)
     status = nf90_inq_varid(ncid, "weasdl", varid)
     status = nf90_put_var(ncid, varid , swe_snd_land(:,:)   , &                 !weasdl = swe_grid/land_frac
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
@@ -869,8 +872,8 @@ contains
     status = nf90_put_var(ncid, varid , tile%snow_depth(:,:,itile)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
   
-    swe_snd_land = 0.  
-    where(tile%land_frac(:,:,itile) > 0.) swe_snd_land = tile%snow_depth(:,:,itile)/tile%land_frac(:,:,itile)
+    swe_snd_land = -1e20  
+    where(tile%land_frac(:,:,itile) > 0.5) swe_snd_land = tile%snow_depth(:,:,itile)/tile%land_frac(:,:,itile)
     status = nf90_inq_varid(ncid, "snodl", varid)
     status = nf90_put_var(ncid, varid , swe_snd_land(:,:)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))

--- a/vector2tile_restart_mod.f90
+++ b/vector2tile_restart_mod.f90
@@ -862,7 +862,7 @@ contains
     status = nf90_put_var(ncid, varid , tile%swe(:,:,itile)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
     
-    swe_snd_land = -1e20   !tile%swe(:,:,itile)
+    swe_snd_land = -1e20   !tile%swe(:,:,itile) !consistent with v17
     where(tile%land_frac(:,:,itile) > 0.5) swe_snd_land = tile%swe(:,:,itile)/tile%land_frac(:,:,itile)
     status = nf90_inq_varid(ncid, "weasdl", varid)
     status = nf90_put_var(ncid, varid , swe_snd_land(:,:)   , &                 !weasdl = swe_grid/land_frac
@@ -872,7 +872,7 @@ contains
     status = nf90_put_var(ncid, varid , tile%snow_depth(:,:,itile)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
   
-    swe_snd_land = -1e20  
+    swe_snd_land = -1e20  !consistent with v17
     where(tile%land_frac(:,:,itile) > 0.5) swe_snd_land = tile%snow_depth(:,:,itile)/tile%land_frac(:,:,itile)
     status = nf90_inq_varid(ncid, "snodl", varid)
     status = nf90_put_var(ncid, varid , swe_snd_land(:,:)   , &


### PR DESCRIPTION
## Describe your changes  
Summarise all code changes included in PR: 
1. bugfix#1: only calculate snodl when land_fraction > 50% to avoid too large numbers in snodl calculation.
2. bugfix#2: read in snwdph and sheleg from tiles instead, otherwise snodl will be dividing land_frac all the time when doing vector2tile conversion.
 
List any associated PRs  in the submodules.
N/A

## Issue ticket number and link
List the git Issue that this PR addresses: 
https://github.com/NOAA-PSL/land-vector2tile/issues/21

## Test output 
Is this PR expected to pass the DA_IMS_test (ie., does it change the output)? 
Yes. It will change the output.
Does it pass the DA_IMS_test? 

If changes to the test results are expected, what are these changes? Provide a link to the output directory when running the test: 

## Checklist before requesting a review
- [x] My branch being merged is up to date with the latest develop. 
- [x] I have performed a self-review of my code by examining the differences that will be merged.
- [x] I have not made any unnecessary code changes / changed any default behavior.
- [x] My code passes the DA_IMS_test, or differences can be explained. 

