### PR TITLE
Add option to update existing restart tiles

### DIFF
--- a/namelist.vector2tile
+++ b/namelist.vector2tile
@@ -27,6 +27,10 @@
 ! Location of tile restart files (tile2vector direction)
 
   tile_restart_path = "/scratch1/NCEPDEV/stmp2/Michael.Barlage/models/vector/v2t_data/workshop/"
+
+! option to update existing tiles (default creates new tiles)
+
+   update_existing_tiles = .false.
   
 ! Path for converted files; if same as tile/vector path, files may be overwritten
 

--- a/namelist_mod.f90
+++ b/namelist_mod.f90
@@ -18,6 +18,7 @@ module namelist_mod
     character*256      :: lndp_output_file = ""
     character(len=128) :: lndp_var_list(max_n_var_lndp)
     integer            :: n_var_lndp
+    logical            :: update_existing_tiles
   end type namelist_type
 
 contains
@@ -40,12 +41,15 @@ contains
     character(len=128)  :: lndp_var_list(max_n_var_lndp)
     integer             :: n_var_lndp
     integer             :: k
+    logical             :: update_existing_tiles
+    
 
     namelist / run_setup  / direction, tile_path, tile_fstub, tile_size,  restart_date, vector_restart_path, &
                             tile_restart_path, output_path, static_filename, &
-                            lndp_layout, lndp_input_file, lndp_output_file, lndp_var_list, n_var_lndp
+                            lndp_layout, lndp_input_file, lndp_output_file, lndp_var_list, n_var_lndp, update_existing_tiles
 
     lndp_var_list = 'XXX'
+    update_existing_tiles = .false.
 
     open(30, file=namelist%namelist_name, form="formatted")
      read(30, run_setup)
@@ -64,6 +68,7 @@ contains
     namelist%lndp_layout         = lndp_layout
     namelist%lndp_input_file     = lndp_input_file
     namelist%lndp_output_file    = lndp_output_file
+    namelist%update_existing_tiles  = update_existing_tiles
 
     n_var_lndp= 0
     do k =1,size(lndp_var_list)

--- a/vector2tile_restart_mod.f90
+++ b/vector2tile_restart_mod.f90
@@ -946,9 +946,9 @@ contains
       start = (/1                , 1                , 1, 1/), &
       count = (/namelist%tile_size, namelist%tile_size, 4, 1/))
 
-    status = nf90_inq_varid(ncid, "tgxy", varid)
-    status = nf90_put_var(ncid, varid , tile%temperature_ground(:,:,itile)   , &
-      start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
+!    status = nf90_inq_varid(ncid, "tgxy", varid)
+!    status = nf90_put_var(ncid, varid , tile%temperature_ground(:,:,itile)   , &
+!      start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
    
     status = nf90_close(ncid)
     if (status /= nf90_noerr) call handle_err(status)

--- a/vector2tile_restart_mod.f90
+++ b/vector2tile_restart_mod.f90
@@ -602,7 +602,7 @@ contains
   inquire(file=vector_filename, exist=file_exists)
   
   if(.not.file_exists) then 
-    print*, trim(vector_filename), " does not exist5"
+    print*, trim(vector_filename), " does not exist"
     print*, "Check paths and file name"
     stop 10
   end if
@@ -694,6 +694,8 @@ contains
   integer             :: dim_id_xdim, dim_id_ydim, dim_id_soil, dim_id_snow, dim_id_snso, dim_id_time
   double precision    :: swe_snd_land(namelist%tile_size, namelist%tile_size)   ! swe/snd over land
 
+  logical             :: file_exists
+
   do itile = 1, 6
 
     !write(tile_filename,'(a17,a19,a5,i1,a3)') "ufs_land_restart.", date, ".tile", itile, ".nc"
@@ -701,6 +703,19 @@ contains
         date(1:4), date(6:7), date(9:10),".",date(12:13), "0000.sfc_data.tile",itile,".nc"
 
     tile_filename = trim(namelist%output_path)//trim(tile_filename)
+
+   if (namelist%update_existing_tiles) then
+   
+    inquire(file=tile_filename, exist=file_exists)
+    if(.not.file_exists) then 
+      print*, trim(tile_filename), " does not exist"
+      print*, "Check namelist setting (update existing file) and paths and file name "
+      stop 10
+    end if
+    status = nf90_open(tile_filename, NF90_WRITE, ncid)
+    if (status /= nf90_noerr) call handle_err(status)
+    
+   else   ! create new file (default) 
     
     print*, "Writing tile file: ", trim(tile_filename)
 
@@ -747,7 +762,6 @@ contains
     status = nf90_def_var(ncid, "zaxis_4", NF90_DOUBLE,    &
       (/dim_id_snso/), varid)
     if (status /= nf90_noerr) call handle_err(status)
-
   
 ! Define variables in the file.
 
@@ -823,7 +837,6 @@ contains
 
     status = nf90_enddef(ncid)
 
-
 ! fill dimension variables 
 
     status = nf90_inq_varid(ncid, "Time", varid)
@@ -849,7 +862,9 @@ contains
     status = nf90_inq_varid(ncid, "zaxis_4", varid)
     if (status /= nf90_noerr) call handle_err(status)
     status = nf90_put_var(ncid, varid ,(/(i, i=1, 7)/) )
-
+    
+   endif ! create new file
+   
 ! Start writing restart file
     
     ! snow_depth/swe variables from the vector restart are grid cell averages
@@ -934,9 +949,10 @@ contains
     status = nf90_inq_varid(ncid, "tgxy", varid)
     status = nf90_put_var(ncid, varid , tile%temperature_ground(:,:,itile)   , &
       start = (/1,1,1/), count = (/namelist%tile_size, namelist%tile_size, 1/))
-      
-  status = nf90_close(ncid)
-
+   
+    status = nf90_close(ncid)
+    if (status /= nf90_noerr) call handle_err(status)
+   
   end do
   
   end subroutine WriteTileRestart


### PR DESCRIPTION
<!-- PR Instructions: 
1. Provide details under all headings below. 
2. Assign Clara and one other person as reviewers. 
3. If the PR is not ready for merging, add the "DRAFT/DO NOT MERGE" label.
4. When a PR is ready to merge, remove the "DRAFT/DO NOT MERGE" and email Clara. 
5. Before requesting that the PR be merged, complete the checklist below. 

Notes on preparing PR, using git can be found in README_git
-->
## Describe your changes  
<!--
Summarise all code changes included in PR: 

List any associated PRs  in the submodules.
-->
The current vector to tile creates new tile files containing snow and soil states from vector restarts (often after running land model and before DA). 
This PR adds an optional switch (default new tiles created as before). 

## Issue ticket number and link
List the git Issue that this PR addresses: 


## Test output 
Is this PR expected to pass the DA_IMS_test (ie., does it change the output)? 
N/A
## Checklist before requesting a review
- [x] My branch being merged is up to date with the latest develop. 
- [x] I have performed a self-review of my code by examining the differences that will be merged.
- [x] I have not made any unnecessary code changes / changed any default behavior.
- [ ] My code passes the DA_IMS_test, or differences can be explained. 

